### PR TITLE
DNP_CORE: Follow the Filesystem Hierarchy Standard of Linux.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine as build
 RUN apk add --update --no-cache \
     docker
 
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 
 FROM alpine
 
 ENV DOCKER_COMPOSE_VERSION 1.22.0
 
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 
 COPY --from=build /usr/bin/docker /usr/bin/docker
 
@@ -51,4 +51,4 @@ ENV COMPOSE_IGNORE_ORPHANS true
 
 COPY entrypoint.sh .
 
-ENTRYPOINT [ "/usr/src/app/entrypoint.sh" ]
+ENTRYPOINT [ "/opt/app/entrypoint.sh" ]

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-docker-compose -f /usr/src/app/DNCORE/docker-compose-bind.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-ipfs.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-ethchain.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-ethforward.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-vpn.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-wamp.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-dappmanager.yml up -d
-docker-compose -f /usr/src/app/DNCORE/docker-compose-admin.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-bind.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-ipfs.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-ethchain.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-ethforward.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-vpn.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-wamp.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-dappmanager.yml up -d
+docker-compose -f /opt/app/DNCORE/docker-compose-admin.yml up -d
 
-if [ -n "`grep \"restart: always\" /usr/src/app/DNCORE/docker-compose-core.yml`" ]; then
-    sed -i 's/restart: always//g' /usr/src/app/DNCORE/docker-compose-core.yml 
-    docker-compose -f /usr/src/app/DNCORE/docker-compose-core.yml up -d
+if [ -n "`grep \"restart: always\" /opt/app/DNCORE/docker-compose-core.yml`" ]; then
+    sed -i 's/restart: always//g' /opt/app/DNCORE/docker-compose-core.yml 
+    docker-compose -f /opt/app/DNCORE/docker-compose-core.yml up -d
 fi

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,7 +9,7 @@
 		"hash": "/ipfs/Qmf2TmqcKk3stw1zt6wzkDW5UrKTCgXNx3k2m5ftr3dip2",
 		"size": 19346978,
 		"volumes": [
-			"/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/",
+			"/opt/dappnode/DNCORE/:/opt/app/DNCORE/",
 			"/var/run/docker.sock:/var/run/docker.sock"
 		],
 		"subnet": "172.33.0.0/16",

--- a/docker-compose-core.yml
+++ b/docker-compose-core.yml
@@ -13,6 +13,6 @@ services:
         image: core.dnp.dappnode.eth:0.1.3
         container_name: DAppNodeCore-core.dnp.dappnode.eth
         volumes:
-            - /usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/
+            - /opt/dappnode/DNCORE/:/opt/app/DNCORE/
             - /var/run/docker.sock:/var/run/docker.sock
         dns: 172.33.1.2


### PR DESCRIPTION
The current data path is installed under /usr/src, a directory reserved
for linux kernel sources. Follow the Filesystem Hierarchy Standard
of Linux, and use /opt/dappnode instead.

Refs: https://github.com/dappnode/DAppNode/issues/39