### PR TITLE
Update to the latest versions

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -32,13 +32,13 @@
   "license": "GPL-3.0",
   "dependencies": {
     "bind.dnp.dappnode.eth": "0.1.6",
-    "ipfs.dnp.dappnode.eth": "0.1.4",
-    "ethchain.dnp.dappnode.eth": "0.1.14",
+    "ipfs.dnp.dappnode.eth": "0.1.5",
+    "ethchain.dnp.dappnode.eth": "0.1.15",
     "ethforward.dnp.dappnode.eth": "0.1.5",
-    "vpn.dnp.dappnode.eth": "0.1.21",
+    "vpn.dnp.dappnode.eth": "0.1.22",
     "wamp.dnp.dappnode.eth": "0.1.1",
-    "admin.dnp.dappnode.eth": "0.1.17",
-    "dappmanager.dnp.dappnode.eth": "0.1.21",
+    "admin.dnp.dappnode.eth": "0.1.18",
+    "dappmanager.dnp.dappnode.eth": "0.1.22",
     "wifi.dnp.dappnode.eth": "0.1.0"
   }
 }

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,13 +1,13 @@
 {
   "name": "core.dnp.dappnode.eth",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Dappnode package responsible for manage the core packages",
   "avatar": "/ipfs/QmQWed5zepncXHvDHt5dZipjVcU7vyydxHmVJV5MF6Wwhr",
   "type": "dncore",
   "image": {
-    "path": "core.dnp.dappnode.eth_0.1.20.tar.xz",
-    "hash": "/ipfs/QmWBz969fDVhNZ2uZdkhPdwBbe4X1m5RUtpxUoq3Z6yF67",
-    "size": 27628442,
+    "path": "",
+    "hash": "",
+    "size": "",
     "volumes": [
       "/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/",
       "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 services:
     core.dnp.dappnode.eth:
         build: ./build
-        image: 'core.dnp.dappnode.eth:0.1.20'
+        image: 'core.dnp.dappnode.eth:0.1.21'
         container_name: DAppNodeCore-core.dnp.dappnode.eth
         volumes:
             - '/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/'


### PR DESCRIPTION
* bind.dnp.dappnode.eth -> 0.1.6
* ipfs.dnp.dappnode.eth -> 0.1.5
* ethchain.dnp.dappnode.eth -> 0.1.15
* ethforward.dnp.dappnode.eth -> 0.1.5
* vpn.dnp.dappnode.eth -> 0.1.22
* wamp.dnp.dappnode.eth -> 0.1.1
* admin.dnp.dappnode.eth -> 0.1.18
* dappmanager.dnp.dappnode.eth -> 0.1.22
* wifi.dnp.dappnode.eth -> 0.1.0