### PR TITLE
Update Admin to v0.2.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,13 +1,13 @@
 {
   "name": "core.dnp.dappnode.eth",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "DAppNode package responsible for manage the core packages",
   "avatar": "/ipfs/QmQWed5zepncXHvDHt5dZipjVcU7vyydxHmVJV5MF6Wwhr",
   "type": "dncore",
   "image": {
-    "path": "core.dnp.dappnode.eth_0.2.0.tar.xz",
-    "hash": "/ipfs/QmQVPKvoEmwz24edEzygfk7fPwg85SRwfBYGJT4uFzBRbV",
-    "size": 27793690,
+    "path": "",
+    "hash": "",
+    "size": "",
     "volumes": [
       "/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/",
       "/var/run/docker.sock:/var/run/docker.sock"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -40,7 +40,7 @@
     "ethforward.dnp.dappnode.eth": "0.2.0",
     "vpn.dnp.dappnode.eth": "0.2.0",
     "wamp.dnp.dappnode.eth": "0.2.0",
-    "admin.dnp.dappnode.eth": "0.2.0",
+    "admin.dnp.dappnode.eth": "0.2.1",
     "dappmanager.dnp.dappnode.eth": "0.2.1",
     "wifi.dnp.dappnode.eth": "0.2.0"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 services:
     core.dnp.dappnode.eth:
         build: ./build
-        image: 'core.dnp.dappnode.eth:0.2.0'
+        image: 'core.dnp.dappnode.eth:0.2.2'
         container_name: DAppNodeCore-core.dnp.dappnode.eth
         volumes:
             - '/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/'


### PR DESCRIPTION
# Changelog

- Do not append .tar.xz to any file, only to directories. Fixes https://github.com/dappnode/DNP_ADMIN/issues/266
- Correct title name
- Fix background color discontinuity
- Don't display the full DNP name if it's from dnp.dappnode.eth
- Fix topnavar-dropdown overflow styling
- Fix link to install in the SDK