### PR TITLE
Fix release

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -22,9 +22,8 @@
     "bind.dnp.dappnode.eth": "0.2.6",
     "ipfs.dnp.dappnode.eth": "0.2.14",
     "vpn.dnp.dappnode.eth": "0.2.8",
-    "dappmanager.dnp.dappnode.eth": "0.2.39",
-    "wifi.dnp.dappnode.eth": "0.2.6",
-    "https.dnp.dappnode.eth": "0.1.0"
+    "dappmanager.dnp.dappnode.eth": "0.2.40",
+    "wifi.dnp.dappnode.eth": "0.2.6"
   },
   "runOrder": ["vpn.dnp.dappnode.eth", "core.dnp.dappnode.eth", "dappmanager.dnp.dappnode.eth"],
   "changelog": "",


### PR DESCRIPTION
- Bump dappmanager version to 0.2.40
- Remove HTTPS package from core installation/updates