### PR TITLE
Remove VPN as mandatory dependency

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "bind.dnp.dappnode.eth": "0.2.6",
     "ipfs.dnp.dappnode.eth": "0.2.14",
-    "vpn.dnp.dappnode.eth": "0.2.8",
     "dappmanager.dnp.dappnode.eth": "0.2.38",
     "wifi.dnp.dappnode.eth": "0.2.6"
   },


### PR DESCRIPTION
In new DAPPMANAGER version it will invite users to install vpn.dnp.dappnode.eth if it's not installed.