### PR TITLE
Add Besu

### DIFF
--- a/src/grab_hashes.sh
+++ b/src/grab_hashes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SWGET="wget -q -O-"
 DAPPNODE_DIR="/usr/src/app"
-CONTENT_HASH_PKGS=(geth nethermind erigon prysm teku lighthouse nimbus)
+CONTENT_HASH_PKGS=(geth besu nethermind erigon prysm teku lighthouse nimbus)
 CONTENT_HASH_FILE="${DAPPNODE_DIR}/packages-content-hash.csv"
 
 grabContentHashes() {


### PR DESCRIPTION
Besu is the only mainnet client hash not gathered by this script which is used in the core, installer, etc.  I kept seeing it in ISO generation logs and install logs for a while but keppt forgetting to make a note of it.