### PR TITLE
Add core optional dependencies

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -26,6 +26,12 @@
     "dappmanager.dnp.dappnode.eth": "0.2.86",
     "wifi.dnp.dappnode.eth": "0.2.9"
   },
+  "optionalDependencies": {
+    "ethical-metrics.dnp.dappnode.eth": "0.1.2",
+    "wireguard.dnp.dappnode.eth": "0.1.3",
+    "vpn.dnp.dappnode.eth": "0.2.10",
+    "https.dnp.dappnode.eth": "0.2.1"
+  },
   "runOrder": [
     "vpn.dnp.dappnode.eth",
     "core.dnp.dappnode.eth",


### PR DESCRIPTION
Add core optional dependencies
- vpn
- wireguard
- https
- ethical metrics

This will force dappnode to update those optional dependencies to the defined version before updating the core