### PR TITLE
ipfs as optional dep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,17 +5,12 @@ on:
       core:
         description: "Bump type, it must be: patch | minor | major"
         required: true
-      dappmanager:
-        description: "Version of the dappmanager. Only numbers"
-        required: true
-      wifi:
-        description: "Version of the wifi. Only numbers"
-        required: true
+      # Mandatory dependencies
       bind:
         description: "Version of the bind. Only numbers"
         required: true
-      ipfs:
-        description: "Version of the ipfs. Only numbers"
+      dappmanager:
+        description: "Version of the dappmanager. Only numbers"
         required: true
       notifications:
         description: "Version of the notifications. Only numbers"
@@ -23,15 +18,32 @@ on:
       premium:
         description: "Version of the premium. Only numbers"
         required: true
+      # Optional dependencies
+      ipfs:
+        description: "Version of the ipfs. Only numbers"
+        required: true
+      wifi:
+        description: "Version of the wifi. Only numbers"
+        required: true
+      wireguard:
+        description: "Version of the wireguard. Only numbers"
+        required: true
+      vpn:
+        description: "Version of the vpn. Only numbers"
+        required: true
 
 env:
   CORE_BUMP_TYPE: ${{ github.event.inputs.core }}
+  # Mandatory dependencies
   BIND_VERSION: ${{ github.event.inputs.bind }}
-  IPFS_VERSION: ${{ github.event.inputs.ipfs }}
   DAPPMANAGER_VERSION: ${{ github.event.inputs.dappmanager }}
-  WIFI_VERSION: ${{ github.event.inputs.wifi }}
   NOTIFICATIONS_VERSION: ${{ github.event.inputs.notifications }}
   PREMIUM_VERSION: ${{ github.event.inputs.premium }}
+  # Optional dependencies
+  IPFS_VERSION: ${{ github.event.inputs.ipfs }}
+  WIFI_VERSION: ${{ github.event.inputs.wifi }}
+  WIREGUARD_VERSION: ${{ github.event.inputs.wireguard }}
+  VPN_VERSION: ${{ github.event.inputs.vpn }}
 
 jobs:
   release:
@@ -46,7 +58,8 @@ jobs:
       - name: Check versions regex
         run: |
           [[ $BIND_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $IPFS_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $DAPPMANAGER_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
-          [[ $WIFI_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $NOTIFICATIONS_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $PREMIUM_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+          [[ $WIFI_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $NOTIFICATIONS_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $PREMIUM_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
+          [[ $WIREGUARD_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ $VPN_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
           { echo "versions introduced in wrong format"; exit 1; }
 
       - uses: actions/checkout@v4
@@ -60,6 +73,8 @@ jobs:
           sed -i -e "/wifi.dnp.dappnode.eth/s/[0-9]*\.[0-9]*\.[0-9]*/"${WIFI_VERSION}"/" dappnode_package.json
           sed -i -e "/notifications.dnp.dappnode.eth/s/[0-9]*\.[0-9]*\.[0-9]*/"${NOTIFICATIONS_VERSION}"/" dappnode_package.json
           sed -i -e "/premium.dnp.dappnode.eth/s/[0-9]*\.[0-9]*\.[0-9]*/"${PREMIUM_VERSION}"/" dappnode_package.json
+          sed -i -e "/wireguard.dnp.dappnode.eth/s/[0-9]*\.[0-9]*\.[0-9]*/"${WIREGUARD_VERSION}"/" dappnode_package.json
+          sed -i -e "/vpn.dnp.dappnode.eth/s/[0-9]*\.[0-9]*\.[0-9]*/"${VPN_VERSION}"/" dappnode_package.json
           cat dappnode_package.json
 
       - name: Setup node

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -23,12 +23,12 @@
   "dependencies": {
     "bind.dnp.dappnode.eth": "0.2.13",
     "dappmanager.dnp.dappnode.eth": "0.2.122",
-    "wifi.dnp.dappnode.eth": "0.2.11",
     "notifications.dnp.dappnode.eth": "0.1.9",
     "premium.dnp.dappnode.eth": "0.1.1"
   },
   "optionalDependencies": {
     "ipfs.dnp.dappnode.eth": "0.2.27",
+    "wifi.dnp.dappnode.eth": "0.2.11",
     "wireguard.dnp.dappnode.eth": "0.1.4",
     "vpn.dnp.dappnode.eth": "0.2.11"
   },

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -22,13 +22,13 @@
   "license": "GPL-3.0",
   "dependencies": {
     "bind.dnp.dappnode.eth": "0.2.13",
-    "ipfs.dnp.dappnode.eth": "0.2.27",
     "dappmanager.dnp.dappnode.eth": "0.2.122",
     "wifi.dnp.dappnode.eth": "0.2.11",
     "notifications.dnp.dappnode.eth": "0.1.9",
     "premium.dnp.dappnode.eth": "0.1.1"
   },
   "optionalDependencies": {
+    "ipfs.dnp.dappnode.eth": "0.2.27",
     "wireguard.dnp.dappnode.eth": "0.1.4",
     "vpn.dnp.dappnode.eth": "0.2.11"
   },


### PR DESCRIPTION
needed for dappnode on mac: 

since we introduced the dappnode "Lite" instalations and other variants, ipfs may not be installed in dappnode anymore. this PR makes ipfs an optional package so non-ipfs dappnodes can keep being that way after updating core